### PR TITLE
feat: Implement Notion Pages API with modular architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,104 @@
 # Notion MCP Server
 
-NotionのMCPサーバー（Node.js + TypeScript）
+A Model Context Protocol (MCP) server for interacting with Notion's API, specifically focused on Pages operations.
 
-## セットアップ
+## Features
+
+- **List Pages**: Query pages from a Notion database
+- **Get Page**: Retrieve a specific page by ID
+- **Create Page**: Create new pages in Notion databases
+- **Update Page**: Update existing page properties
+
+## Setup
+
+### 1. Install Dependencies
 
 ```bash
 npm install
 ```
 
-## 開発用コマンド
+### 2. Environment Configuration
 
-- 開発サーバー起動: `npm run dev`
-- ビルド: `npm run build`
-- 本番起動: `npm start`
+Copy the example environment file and configure your Notion API credentials:
 
-## ディレクトリ構成
+```bash
+cp env.example .env
+```
 
-- `src/` : TypeScriptソースコード
-- `dist/` : ビルド後の出力
+Edit `.env` and add your Notion API key:
+
+```
+NOTION_API_KEY=your_notion_integration_token_here
+NOTION_DATABASE_ID=your_database_id_here
+```
+
+### 3. Get Notion API Key
+
+1. Go to [Notion Developers](https://developers.notion.com/)
+2. Create a new integration
+3. Copy the "Internal Integration Token"
+4. Add the integration to your workspace
+
+### 4. Build the Project
+
+```bash
+npm run build
+```
+
+## Usage
+
+### As an MCP Server
+
+The server can be used with any MCP-compatible client:
+
+```bash
+npm run mcp
+```
+
+### Available Tools
+
+#### list_pages
+List pages from a Notion database.
+
+Parameters:
+- `database_id` (required): The ID of the database
+- `filter` (optional): Filter criteria
+- `sorts` (optional): Sorting options
+- `page_size` (optional): Number of pages to return (max 100)
+
+#### get_page
+Get a specific page by ID.
+
+Parameters:
+- `page_id` (required): The ID of the page to retrieve
+
+#### create_page
+Create a new page in a Notion database.
+
+Parameters:
+- `parent` (required): The parent object (database or page)
+- `properties` (required): The properties of the page
+- `children` (optional): Block content for the page
+
+#### update_page
+Update an existing page.
+
+Parameters:
+- `page_id` (required): The ID of the page to update
+- `properties` (required): The properties to update
+
+## Development
+
+```bash
+# Start development server
+npm run dev
+
+# Build for production
+npm run build
+```
+
+## Notion API Documentation
+
+For more information about the Notion API, visit:
+- [Notion API Documentation](https://developers.notion.com/reference)
+- [Pages API Reference](https://developers.notion.com/reference/post-page)

--- a/env.example
+++ b/env.example
@@ -1,0 +1,6 @@
+# Notion API Configuration
+NOTION_API_KEY=your_notion_integration_token_here
+NOTION_DATABASE_ID=your_database_id_here
+
+# MCP Server Configuration
+MCP_SERVER_PORT=3000 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.16.0",
+        "@notionhq/client": "^4.0.1",
+        "dotenv": "^17.2.0",
         "express": "^4.18.2",
         "zod": "^3.25.76"
       },
@@ -372,6 +374,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/@notionhq/client": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-4.0.1.tgz",
+      "integrity": "sha512-SdILqiiThECLR2KDUOvl4JqRaJWBwDYaEw/f0qu+G6rKN/QUCkaJ84vN5MgBw1yKsMAsKxBlDazs3Jw6vv2ikA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -836,6 +847,18 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.0.tgz",
+      "integrity": "sha512-Q4sgBT60gzd0BB0lSyYD3xM4YxrXA9y4uBDof1JNYGzOXrQdQ6yX+7XIAqoFOGQFOTK1D3Hts5OllpxMDZFONQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -6,12 +6,15 @@
   "scripts": {
     "start": "node dist/index.js",
     "dev": "nodemon src/index.ts",
-    "build": "tsc"
+    "build": "tsc",
+    "mcp": "node dist/index.js"
   },
   "author": "",
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.16.0",
+    "@notionhq/client": "^4.0.1",
+    "dotenv": "^17.2.0",
     "express": "^4.18.2",
     "zod": "^3.25.76"
   },

--- a/src/config/notion.ts
+++ b/src/config/notion.ts
@@ -1,0 +1,17 @@
+import { Client as NotionClient } from '@notionhq/client';
+import dotenv from 'dotenv';
+
+// Load environment variables
+dotenv.config();
+
+// Initialize Notion client
+export const notionClient = new NotionClient({
+  auth: process.env.NOTION_API_KEY,
+});
+
+// Validate required environment variables
+export function validateEnvironment() {
+  if (!process.env.NOTION_API_KEY) {
+    throw new Error('NOTION_API_KEY environment variable is required');
+  }
+} 

--- a/src/handlers/pages-handler.ts
+++ b/src/handlers/pages-handler.ts
@@ -1,0 +1,84 @@
+import { Client as NotionClient } from '@notionhq/client';
+import { ListPagesArgs, GetPageArgs, CreatePageArgs, UpdatePageArgs } from '../types/notion.js';
+
+export class PagesHandler {
+  private notion: NotionClient;
+
+  constructor(notion: NotionClient) {
+    this.notion = notion;
+  }
+
+  async handleListPages(args: ListPagesArgs) {
+    const { database_id, filter, sorts, page_size = 100 } = args;
+    
+    const response = await this.notion.databases.query({
+      database_id,
+      filter,
+      sorts,
+      page_size,
+    });
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(response, null, 2),
+        },
+      ],
+    };
+  }
+
+  async handleGetPage(args: GetPageArgs) {
+    const { page_id } = args;
+    
+    const response = await this.notion.pages.retrieve({
+      page_id,
+    });
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(response, null, 2),
+        },
+      ],
+    };
+  }
+
+  async handleCreatePage(args: CreatePageArgs) {
+    const { parent, properties, children } = args;
+    
+    const response = await this.notion.pages.create({
+      parent: parent as any,
+      properties,
+      children,
+    });
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(response, null, 2),
+        },
+      ],
+    };
+  }
+
+  async handleUpdatePage(args: UpdatePageArgs) {
+    const { page_id, properties } = args;
+    
+    const response = await this.notion.pages.update({
+      page_id,
+      properties,
+    });
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(response, null, 2),
+        },
+      ],
+    };
+  }
+} 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,1 @@
-import express from 'express';
-
-const app = express();
-const port = process.env.PORT || 3000;
-
-app.get('/health', (_req, res) => {
-  res.json({ status: 'ok' });
-});
-
-app.listen(port, () => {
-  console.log(`MCP server listening at http://localhost:${port}`);
-}); 
+import './server/notion-mcp-server.js'; 

--- a/src/server/notion-mcp-server.ts
+++ b/src/server/notion-mcp-server.ts
@@ -1,0 +1,71 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { notionClient, validateEnvironment } from '../config/notion.js';
+import { PagesHandler } from '../handlers/pages-handler.js';
+import { pagesTools } from '../tools/pages.js';
+
+// Validate environment
+validateEnvironment();
+
+// Initialize handlers
+const pagesHandler = new PagesHandler(notionClient);
+
+// Create MCP server
+const server = new Server(
+  {
+    name: 'notion-mcp-server',
+    version: '1.0.0',
+  },
+  {
+    capabilities: {
+      tools: {},
+    },
+  }
+);
+
+// Handle list tools request
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return {
+    tools: pagesTools,
+  };
+});
+
+// Handle call tool request
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+
+  try {
+    switch (name) {
+      case 'list_pages':
+        return await pagesHandler.handleListPages(args as any);
+      case 'get_page':
+        return await pagesHandler.handleGetPage(args as any);
+      case 'create_page':
+        return await pagesHandler.handleCreatePage(args as any);
+      case 'update_page':
+        return await pagesHandler.handleUpdatePage(args as any);
+      default:
+        throw new Error(`Unknown tool: ${name}`);
+    }
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+});
+
+// Start the server
+const transport = new StdioServerTransport();
+server.connect(transport);
+
+console.log('Notion MCP Server started'); 

--- a/src/tools/pages.ts
+++ b/src/tools/pages.ts
@@ -1,0 +1,85 @@
+import { Tool } from '@modelcontextprotocol/sdk/types.js';
+
+// Define tools for Notion Pages API
+export const pagesTools: Tool[] = [
+  {
+    name: 'list_pages',
+    description: 'List pages from a Notion database',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        database_id: {
+          type: 'string',
+          description: 'The ID of the database to list pages from',
+        },
+        filter: {
+          type: 'object',
+          description: 'Optional filter to apply to the pages',
+        },
+        sorts: {
+          type: 'array',
+          description: 'Optional sorting options',
+        },
+        page_size: {
+          type: 'number',
+          description: 'Number of pages to return (max 100)',
+        },
+      },
+      required: ['database_id'],
+    },
+  },
+  {
+    name: 'get_page',
+    description: 'Get a specific page by ID',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        page_id: {
+          type: 'string',
+          description: 'The ID of the page to retrieve',
+        },
+      },
+      required: ['page_id'],
+    },
+  },
+  {
+    name: 'create_page',
+    description: 'Create a new page in a Notion database',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        parent: {
+          type: 'object',
+          description: 'The parent object (database or page)',
+        },
+        properties: {
+          type: 'object',
+          description: 'The properties of the page',
+        },
+        children: {
+          type: 'array',
+          description: 'Optional block content for the page',
+        },
+      },
+      required: ['parent', 'properties'],
+    },
+  },
+  {
+    name: 'update_page',
+    description: 'Update an existing page',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        page_id: {
+          type: 'string',
+          description: 'The ID of the page to update',
+        },
+        properties: {
+          type: 'object',
+          description: 'The properties to update',
+        },
+      },
+      required: ['page_id', 'properties'],
+    },
+  },
+]; 

--- a/src/types/notion.ts
+++ b/src/types/notion.ts
@@ -1,0 +1,49 @@
+// Notion API related types
+export interface NotionPage {
+  id: string;
+  object: 'page';
+  created_time: string;
+  last_edited_time: string;
+  parent: any;
+  properties: Record<string, any>;
+  url: string;
+}
+
+export interface NotionDatabase {
+  id: string;
+  object: 'database';
+  title: Array<{ type: string; text: { content: string } }>;
+  properties: Record<string, any>;
+}
+
+export interface NotionBlock {
+  id: string;
+  object: 'block';
+  type: string;
+  [key: string]: any;
+}
+
+export interface ListPagesArgs {
+  database_id: string;
+  filter?: any;
+  sorts?: any[];
+  page_size?: number;
+}
+
+export interface GetPageArgs {
+  page_id: string;
+}
+
+export interface CreatePageArgs {
+  parent: {
+    database_id?: string;
+    page_id?: string;
+  };
+  properties: Record<string, any>;
+  children?: any[];
+}
+
+export interface UpdatePageArgs {
+  page_id: string;
+  properties: Record<string, any>;
+} 


### PR DESCRIPTION
## 🚀 Notion Pages API Implementation

This PR implements a comprehensive Notion Pages API integration using the Model Context Protocol (MCP) with a modular, maintainable architecture.

### ✨ Features Added

- **Pages API Tools**: Complete implementation of Notion Pages API operations
  - `list_pages`: Query pages from a Notion database
  - `get_page`: Retrieve a specific page by ID
  - `create_page`: Create new pages in Notion databases
  - `update_page`: Update existing page properties

### 🏗️ Architecture Improvements

- **Modular File Structure**: Organized code into logical modules
  - `src/config/`: Configuration management
  - `src/types/`: TypeScript type definitions
  - `src/tools/`: MCP tool definitions
  - `src/handlers/`: API operation handlers
  - `src/server/`: MCP server implementation

### 📦 Dependencies Added

- `@notionhq/client`: Official Notion API client
- `dotenv`: Environment variable management

### 🔧 Configuration

- Added `env.example` with Notion API configuration template
- Environment variable validation
- Comprehensive error handling

### 📚 Documentation

- Updated README with detailed setup instructions
- Added usage examples for all tools
- Included Notion API documentation links

### 🧪 Testing

- All code compiles successfully with TypeScript
- Modular structure allows for easy testing of individual components
- Ready for integration with MCP-compatible clients

### 🔮 Future Extensibility

The modular architecture makes it easy to add additional Notion API features:
- Blocks API
- Databases API
- Users API
- Search API

### 📋 Checklist

- [x] Implement Pages API tools
- [x] Create modular file structure
- [x] Add comprehensive type definitions
- [x] Implement error handling
- [x] Add environment configuration
- [x] Update documentation
- [x] Test compilation
- [x] Follow TypeScript best practices

### 🚀 Usage

After merging, users can:

1. Copy `env.example` to `.env` and configure Notion API key
2. Run `npm install` to install dependencies
3. Run `npm run build` to compile
4. Use with any MCP-compatible client

This implementation provides a solid foundation for Notion API integration while maintaining excellent code organization and extensibility.