### PR TITLE
Fix: Enable tools loading and add debug logging

### DIFF
--- a/src/config/notion.ts
+++ b/src/config/notion.ts
@@ -14,6 +14,10 @@ export const NOTION_DATABASE_ID = process.env.NOTION_DATABASE_ID;
 
 // Validate required environment variables
 export function validateEnvironment() {
+  console.log('Validating environment variables...');
+  console.log('NOTION_API_KEY:', process.env.NOTION_API_KEY ? 'set' : 'not set');
+  console.log('NOTION_DATABASE_ID:', process.env.NOTION_DATABASE_ID ? 'set' : 'not set');
+  
   if (!process.env.NOTION_API_KEY) {
     throw new Error('NOTION_API_KEY environment variable is required');
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,4 @@
-import './server/notion-mcp-server'; 
+import { main } from './server/notion-mcp-server';
+
+// Start the server
+main(); 

--- a/src/server/notion-mcp-server.ts
+++ b/src/server/notion-mcp-server.ts
@@ -9,11 +9,20 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 
 export function initializeServer() {
+  console.log('Initializing Notion MCP Server...');
+  
   // Validate environment
-  validateEnvironment();
+  try {
+    validateEnvironment();
+    console.log('Environment validation passed');
+  } catch (error) {
+    console.error('Environment validation failed:', error);
+    throw error;
+  }
 
   // Initialize handlers
   const pagesHandler = new PagesHandler(notionClient);
+  console.log('Pages handler initialized');
 
   // Create MCP server
   const server = new Server(
@@ -27,9 +36,12 @@ export function initializeServer() {
       },
     }
   );
+  console.log('MCP Server created');
 
   // Handle list tools request
   server.setRequestHandler(ListToolsRequestSchema, async () => {
+    console.log('List tools request received');
+    console.log('Available tools:', pagesTools.map(tool => tool.name));
     return {
       tools: pagesTools,
     };
@@ -38,6 +50,7 @@ export function initializeServer() {
   // Handle call tool request
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args } = request.params;
+    console.log('Call tool request received:', name);
 
     try {
       switch (name) {
@@ -53,6 +66,7 @@ export function initializeServer() {
           throw new Error(`Unknown tool: ${name}`);
       }
     } catch (error) {
+      console.error('Tool execution error:', error);
       return {
         content: [
           {
@@ -65,15 +79,17 @@ export function initializeServer() {
     }
   });
 
+  console.log('Server initialization complete');
   return server;
 }
 
 export function main() {
+  console.log('Starting Notion MCP Server...');
   const server = initializeServer();
   // Start the server
   const transport = new StdioServerTransport();
   server.connect(transport);
-  console.log('Notion MCP Server started');
+  console.log('Notion MCP Server started and connected to transport');
 }
 
 if (require.main === module) {


### PR DESCRIPTION
## 概要
Notion MCPサーバーのtoolsがロードできない問題を修正し、デバッグログを追加しました。

## 変更内容

### 🔧 修正
- **src/index.ts**: `main()`関数の呼び出しを追加してサーバーを正しく起動
- **src/server/notion-mcp-server.ts**: 包括的なデバッグログを追加
- **src/config/notion.ts**: 環境変数検証のログを追加

### 📝 詳細な変更

#### src/index.ts
```diff
- import './server/notion-mcp-server';
+ import { main } from './server/notion-mcp-server';
+ 
+ // Start the server
+ main();
```

#### src/server/notion-mcp-server.ts
- サーバー初期化プロセスの各段階でログを追加
- ツールリクエストのログを追加
- エラーハンドリングの改善

#### src/config/notion.ts
- 環境変数の検証時にログを出力
- デバッグ情報の追加

## 問題の原因
元々、`index.ts`で`main()`関数が呼び出されていなかったため、MCPサーバーが起動していませんでした。

## テスト結果
- ✅ MCPサーバーが正常に起動
- ✅ toolsが正しくロードされる
- ✅ `list_pages`、`get_page`、`create_page`、`update_page`ツールが利用可能
- ✅ 環境変数の検証が正常に動作
- ✅ デバッグログが適切に出力される

## 確認方法
```bash
# サーバーを起動
npm run build
node dist/index.js

# toolsリストを確認
echo '{"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}' | node dist/index.js
```

この修正により、Notion MCPサーバーのtoolsが正常にロードされ、デバッグが容易になりました。